### PR TITLE
Change thread creation on warning for update.

### DIFF
--- a/common/src/main/java/us/ajg0702/queue/common/EventHandlerImpl.java
+++ b/common/src/main/java/us/ajg0702/queue/common/EventHandlerImpl.java
@@ -143,15 +143,13 @@ public class EventHandlerImpl implements EventHandler {
 
     @Override
     public void onPlayerJoin(AdaptedPlayer player) {
-        new Thread(() -> {
-            try {
-                TimeUnit.SECONDS.sleep(2);
-            } catch (InterruptedException ignored) {
+        main.getTaskManager().runLater(() -> {
+            if(player.isConnected()){
+                if (main.getUpdater().isUpdateAvailable() && player.hasPermission("ajqueue.manage.update")) {
+                    player.sendMessage(main.getMessages().getComponent("updater.update-available"));
+                }
             }
-            if (main.getUpdater().isUpdateAvailable() && player.hasPermission("ajqueue.manage.update")) {
-                player.sendMessage(main.getMessages().getComponent("updater.update-available"));
-            }
-        }).start();
+        },1, TimeUnit.SECONDS);
 
         ImmutableList<QueuePlayer> queues = main.getQueueManager().findPlayerInQueues(player);
         for(QueuePlayer queuePlayer : queues) {

--- a/common/src/main/java/us/ajg0702/queue/common/TaskManager.java
+++ b/common/src/main/java/us/ajg0702/queue/common/TaskManager.java
@@ -10,7 +10,7 @@ public class TaskManager {
     final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
     final ScheduledExecutorService updateExecutor = Executors.newScheduledThreadPool(1);
 
-    final ExecutorService serversUpdateExecutor = Executors.newCachedThreadPool();
+    final ExecutorService serversUpdateExecutor = Executors.newSingleThreadExecutor();
 
     final QueueMain main;
     public TaskManager(QueueMain main) {


### PR DESCRIPTION
This can decrease the performance of a proxy linearly if a lot of players are constantly connecting, server switching, and logging in and out all the time.

With this PR the abnormal thread creation is stopped and it is only scheduled for 1s,
this should decrease the cpu usage of ajqueue a bit as well as minimize its resource comsumption specially on Velocity proxies.