### PR TITLE
Increase limit for queue-server-delay to 15 seconds

### DIFF
--- a/common/src/main/java/us/ajg0702/queue/common/EventHandlerImpl.java
+++ b/common/src/main/java/us/ajg0702/queue/common/EventHandlerImpl.java
@@ -118,7 +118,7 @@ public class EventHandlerImpl implements EventHandler {
                                             player.hasPermission("ajqueue.queueserver." + to.getName())
                             )
                 ) {
-                    int delay = Math.min(main.getConfig().getInt("queue-server-delay"), 3000);
+                    int delay = Math.min(main.getConfig().getInt("queue-server-delay"), 15000);
                     Runnable task = () -> {
                         if(to.getServers().contains(player.getCurrentServer())) return;
                         main.getQueueManager().addToQueue(player, to);

--- a/common/src/main/java/us/ajg0702/queue/common/QueueManagerImpl.java
+++ b/common/src/main/java/us/ajg0702/queue/common/QueueManagerImpl.java
@@ -471,7 +471,7 @@ public class QueueManagerImpl implements QueueManager {
                         return;
                     }
                     long lastSwitch = main.getServerTimeManager().getLastServerChange(player);
-                    int delay = Math.min(Math.max(main.getConfig().getInt("queue-server-delay"), 0), 3000);
+                    int delay = Math.min(Math.max(main.getConfig().getInt("queue-server-delay"), 0), 15000);
                     if(System.currentTimeMillis() - lastSwitch < delay + 1000 || !player.getCurrentServer().equals(from)) {
                         return;
                     }

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -87,7 +87,7 @@ queue-servers:
 # How much should we delay queueing players in queue servers?
 # You should only use this if you have issues with the instant sending.
 # Set to 0 or any negative number to disable
-# In milliseconds. Maximum value is 3000 (3 seconds)
+# In milliseconds. Maximum value is 15000 (15 seconds)
 #  Default: 0
 queue-server-delay: 0
 


### PR DESCRIPTION
Bedrock edition (mainly Switch with its poor optimization) tends to crash if it switches worlds to quickly during the loading process

I've increased how long the `queue-server-delay` option can be so Switch Bedrock doesn't crash when trying to join a server that has instant queue joining