### PR TITLE
Added 3 New Events

### DIFF
--- a/api/src/main/java/us/ajg0702/queue/api/events/AutoQueueEvent.java
+++ b/api/src/main/java/us/ajg0702/queue/api/events/AutoQueueEvent.java
@@ -1,0 +1,41 @@
+package us.ajg0702.queue.api.events;
+
+import us.ajg0702.queue.api.players.AdaptedPlayer;
+
+/**
+ * Called before AjQueue queues a player for a server.
+ * Use Case: View/Change the server that the player is re-queued for.
+ */
+@SuppressWarnings("unused")
+public class AutoQueueEvent implements Event {
+    private final AdaptedPlayer player;
+    private String targetServer;
+
+    public AutoQueueEvent(AdaptedPlayer player, String targetServer) {
+        this.player = player;
+        this.targetServer = targetServer;
+    }
+
+    /**
+     * @return the player that is being re-queued
+     */
+    public AdaptedPlayer getPlayer() {
+        return player;
+    }
+
+    /**
+     * @return The name of the server AjQueue will queue the player for.
+     */
+    public String getTargetServer() {
+        return targetServer;
+    }
+
+    /**
+     * Set the name of the server AjQueue will queue the player for.
+     * @param targetServer The name of the server to queue the player for.
+     */
+    public void setTargetServer(String targetServer) {
+        this.targetServer = targetServer;
+    }
+}
+

--- a/api/src/main/java/us/ajg0702/queue/api/events/AutoQueueOnKickEvent.java
+++ b/api/src/main/java/us/ajg0702/queue/api/events/AutoQueueOnKickEvent.java
@@ -3,15 +3,19 @@ package us.ajg0702.queue.api.events;
 import us.ajg0702.queue.api.players.AdaptedPlayer;
 
 /**
- * Called before AjQueue queues a player for a server.
- * Use Case: View/Change the server that the player is re-queued for.
+ * Called before AjQueue auto-queues a player for a server. (on player kick)
+ * Use Case: View/Change the server that the player is auto-queued for.
+ * If canceled, the player will not be queued to any server.
+ * If you cancel this event, it is up to you to send a message telling the player why they were not auto-queued.
  */
 @SuppressWarnings("unused")
-public class AutoQueueEvent implements Event {
+public class AutoQueueOnKickEvent implements Event, Cancellable {
     private final AdaptedPlayer player;
     private String targetServer;
 
-    public AutoQueueEvent(AdaptedPlayer player, String targetServer) {
+    private boolean cancelled = false;
+
+    public AutoQueueOnKickEvent(AdaptedPlayer player, String targetServer) {
         this.player = player;
         this.targetServer = targetServer;
     }
@@ -36,6 +40,14 @@ public class AutoQueueEvent implements Event {
      */
     public void setTargetServer(String targetServer) {
         this.targetServer = targetServer;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 }
 

--- a/api/src/main/java/us/ajg0702/queue/api/events/BuildServersEvent.java
+++ b/api/src/main/java/us/ajg0702/queue/api/events/BuildServersEvent.java
@@ -1,0 +1,59 @@
+package us.ajg0702.queue.api.events;
+
+import org.jetbrains.annotations.Nullable;
+import us.ajg0702.queue.api.server.AdaptedServer;
+
+import java.util.*;
+
+/**
+ * Called before AjQueue attempts to re-compile its list of QueueServers
+ * Use Case: Add/Remove an AdaptedServer from being registered as a QueueServer.
+ */
+@SuppressWarnings("unused")
+public class BuildServersEvent implements Event {
+    private final Map<String, AdaptedServer> servers = new HashMap<>();
+
+    public BuildServersEvent(List<? extends AdaptedServer> servers) {
+        // Compile a map of server names to servers
+        for(AdaptedServer server : servers) {
+            this.servers.put(server.getName(), server);
+        }
+    }
+
+    /**
+     * @see #addServer(AdaptedServer)
+     * @see #removeServer(AdaptedServer)
+     * @see #removeServer(String)
+     * @return an immutable view of the servers that will be registered as QueueServers.
+     */
+    public List<AdaptedServer> getServers() {
+        return Collections.unmodifiableList(new ArrayList<>(servers.values()));
+    }
+
+    /**
+     * Add a server to be registered as a QueueServer.
+     * @param server The server to add
+     * @return The previous AdaptedServer with that name, or null if there was no previous server
+     */
+    public @Nullable AdaptedServer addServer(AdaptedServer server) {
+        return servers.put(server.getName(), server);
+    }
+
+    /**
+     * Remove a server, preventing it from being registered as a QueueServer.
+     * @param server The AdaptedServer to remove
+     * @return true if the server was removed, false if it was not found
+     */
+    public boolean removeServer(AdaptedServer server) {
+        return servers.remove(server.getName()) != null;
+    }
+
+    /**
+     * Remove a server, preventing it from being registered as a QueueServer.
+     * @param name The name of the server to remove
+     * @return true if the server was removed, false if it was not found
+     */
+    public boolean removeServer(String name) {
+        return servers.remove(name) != null;
+    }
+}

--- a/api/src/main/java/us/ajg0702/queue/api/events/BuildServersEvent.java
+++ b/api/src/main/java/us/ajg0702/queue/api/events/BuildServersEvent.java
@@ -12,6 +12,7 @@ import java.util.*;
 @SuppressWarnings("unused")
 public class BuildServersEvent implements Event {
     private final Map<String, AdaptedServer> servers = new HashMap<>();
+    private final Map<String, List<AdaptedServer>> groups = new HashMap<>();
 
     public BuildServersEvent(List<? extends AdaptedServer> servers) {
         // Compile a map of server names to servers
@@ -56,4 +57,41 @@ public class BuildServersEvent implements Event {
     public boolean removeServer(String name) {
         return servers.remove(name) != null;
     }
+
+
+    /**
+     * @see #addGroup(String, List)
+     * @see #removeGroup(String)
+     * @return an immutable list of the sets of servers that will be registered as group QueueServers.
+     */
+    public List<List<AdaptedServer>> getGroups() {
+        return Collections.unmodifiableList(new ArrayList<>(groups.values()));
+    }
+
+    /**
+     * Used internally
+     */
+    public Set<Map.Entry<String, List<AdaptedServer>>> groupEntrySet() {
+        return groups.entrySet();
+    }
+
+    /**
+     * Add a server-group to be registered by the Queue Manager.
+     * @param name The name of the server-group
+     * @param servers The servers to add to the group
+     * @return The previous server list with that name, or null if there was no previous data
+     */
+    public @Nullable List<AdaptedServer> addGroup(String name, List<AdaptedServer> servers) {
+        return groups.put(name, servers);
+    }
+
+    /**
+     * Remove a server, preventing it from being registered as a QueueServer.
+     * @param name The name of the server to remove
+     * @return true if the server was removed, false if it was not found
+     */
+    public boolean removeGroup(String name) {
+        return groups.remove(name) != null;
+    }
+
 }

--- a/api/src/main/java/us/ajg0702/queue/api/events/PreConnectEvent.java
+++ b/api/src/main/java/us/ajg0702/queue/api/events/PreConnectEvent.java
@@ -1,20 +1,21 @@
 package us.ajg0702.queue.api.events;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import us.ajg0702.queue.api.players.AdaptedPlayer;
 import us.ajg0702.queue.api.server.AdaptedServer;
 
 /**
  * Called before AjQueue attempts to connect a player to a proxy server (via Bungee or Velocity)
  * You can use setTargetServer to provide a custom AdaptedServer object for the player to connect to.
- * You can use setDelayStatus to temporarily delay the player from connecting. They will still be in the queue.
+ * If canceled, the player will not be connected to the target server.
+ * If you cancel this event, it is up to you to send a message telling the player why they were not connected.
  */
 @SuppressWarnings("unused")
-public class PreConnectEvent implements Event {
+public class PreConnectEvent implements Event, Cancellable {
     private @NotNull AdaptedServer targetServer;
     private final @NotNull AdaptedPlayer adaptedPlayer;
-    private @Nullable String delayStatus = null;
+
+    private boolean cancelled = false;
 
     public PreConnectEvent(@NotNull AdaptedServer targetServer, @NotNull AdaptedPlayer adaptedPlayer) {
         this.targetServer = targetServer;
@@ -38,26 +39,18 @@ public class PreConnectEvent implements Event {
     }
 
     /**
-     * Set the reason why the player should be delayed from connecting.
-     *
-     * @param delayStatus The reason why the player should be delayed from connecting
-     */
-    public void setDelayStatus(@Nullable String delayStatus) {
-        this.delayStatus = delayStatus;
-    }
-
-    /**
-     * @return The reason why the player should be delayed from connecting
-     */
-    public @Nullable String getDelayStatus() {
-        return delayStatus;
-    }
-
-    /**
      * @return The player that is being connected to the server
      */
     public @NotNull AdaptedPlayer getPlayer() {
         return adaptedPlayer;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 }
 

--- a/api/src/main/java/us/ajg0702/queue/api/events/PreConnectEvent.java
+++ b/api/src/main/java/us/ajg0702/queue/api/events/PreConnectEvent.java
@@ -1,11 +1,11 @@
 package us.ajg0702.queue.api.events;
 
 import org.jetbrains.annotations.NotNull;
-import us.ajg0702.queue.api.players.AdaptedPlayer;
+import us.ajg0702.queue.api.players.QueuePlayer;
 import us.ajg0702.queue.api.server.AdaptedServer;
 
 /**
- * Called before AjQueue attempts to connect a player to a proxy server (via Bungee or Velocity)
+ * Called before AjQueue attempts to connect a player to an AdaptedServer (via Bungee or Velocity)
  * You can use setTargetServer to provide a custom AdaptedServer object for the player to connect to.
  * If canceled, the player will not be connected to the target server.
  * If you cancel this event, it is up to you to send a message telling the player why they were not connected.
@@ -13,13 +13,13 @@ import us.ajg0702.queue.api.server.AdaptedServer;
 @SuppressWarnings("unused")
 public class PreConnectEvent implements Event, Cancellable {
     private @NotNull AdaptedServer targetServer;
-    private final @NotNull AdaptedPlayer adaptedPlayer;
+    private final @NotNull QueuePlayer queuePlayer;
 
     private boolean cancelled = false;
 
-    public PreConnectEvent(@NotNull AdaptedServer targetServer, @NotNull AdaptedPlayer adaptedPlayer) {
+    public PreConnectEvent(@NotNull AdaptedServer targetServer, @NotNull QueuePlayer queuePlayer) {
         this.targetServer = targetServer;
-        this.adaptedPlayer = adaptedPlayer;
+        this.queuePlayer = queuePlayer;
     }
 
     /**
@@ -41,8 +41,8 @@ public class PreConnectEvent implements Event, Cancellable {
     /**
      * @return The player that is being connected to the server
      */
-    public @NotNull AdaptedPlayer getPlayer() {
-        return adaptedPlayer;
+    public @NotNull QueuePlayer getPlayer() {
+        return queuePlayer;
     }
 
     public boolean isCancelled() {

--- a/api/src/main/java/us/ajg0702/queue/api/events/PreConnectEvent.java
+++ b/api/src/main/java/us/ajg0702/queue/api/events/PreConnectEvent.java
@@ -1,0 +1,63 @@
+package us.ajg0702.queue.api.events;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import us.ajg0702.queue.api.players.AdaptedPlayer;
+import us.ajg0702.queue.api.server.AdaptedServer;
+
+/**
+ * Called before AjQueue attempts to connect a player to a proxy server (via Bungee or Velocity)
+ * You can use setTargetServer to provide a custom AdaptedServer object for the player to connect to.
+ * You can use setDelayStatus to temporarily delay the player from connecting. They will still be in the queue.
+ */
+@SuppressWarnings("unused")
+public class PreConnectEvent implements Event {
+    private @NotNull AdaptedServer targetServer;
+    private final @NotNull AdaptedPlayer adaptedPlayer;
+    private @Nullable String delayStatus = null;
+
+    public PreConnectEvent(@NotNull AdaptedServer targetServer, @NotNull AdaptedPlayer adaptedPlayer) {
+        this.targetServer = targetServer;
+        this.adaptedPlayer = adaptedPlayer;
+    }
+
+    /**
+     * Set the target server to connect the player to. (Override default behavior with a custom server)
+     *
+     * @param targetServer the target server (AdaptedServer)
+     */
+    public void setTargetServer(@NotNull AdaptedServer targetServer) {
+        this.targetServer = targetServer;
+    }
+
+    /**
+     * @return The target server that the player is trying to connect to
+     */
+    public @NotNull AdaptedServer getTargetServer() {
+        return targetServer;
+    }
+
+    /**
+     * Set the reason why the player should be delayed from connecting.
+     *
+     * @param delayStatus The reason why the player should be delayed from connecting
+     */
+    public void setDelayStatus(@Nullable String delayStatus) {
+        this.delayStatus = delayStatus;
+    }
+
+    /**
+     * @return The reason why the player should be delayed from connecting
+     */
+    public @Nullable String getDelayStatus() {
+        return delayStatus;
+    }
+
+    /**
+     * @return The player that is being connected to the server
+     */
+    public @NotNull AdaptedPlayer getPlayer() {
+        return adaptedPlayer;
+    }
+}
+

--- a/api/src/main/java/us/ajg0702/queue/api/players/QueuePlayer.java
+++ b/api/src/main/java/us/ajg0702/queue/api/players/QueuePlayer.java
@@ -1,5 +1,6 @@
 package us.ajg0702.queue.api.players;
 
+import org.jetbrains.annotations.NotNull;
 import us.ajg0702.queue.api.queues.QueueServer;
 import us.ajg0702.queue.api.server.AdaptedServer;
 
@@ -75,4 +76,6 @@ public interface QueuePlayer {
      * @return the server that the player was in when they joined the queue
      */
     AdaptedServer getInitialServer();
+
+    void connect(@NotNull AdaptedServer server);
 }

--- a/api/src/main/java/us/ajg0702/queue/api/players/QueuePlayer.java
+++ b/api/src/main/java/us/ajg0702/queue/api/players/QueuePlayer.java
@@ -77,5 +77,8 @@ public interface QueuePlayer {
      */
     AdaptedServer getInitialServer();
 
+    /**
+     * Attempts a connection to the provided AdaptedServer, calling PreConnectEvent before AdaptedPlayer.connect(...)
+     */
     void connect(@NotNull AdaptedServer server);
 }

--- a/common/src/main/java/us/ajg0702/queue/common/EventHandlerImpl.java
+++ b/common/src/main/java/us/ajg0702/queue/common/EventHandlerImpl.java
@@ -6,7 +6,7 @@ import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import us.ajg0702.queue.api.EventHandler;
-import us.ajg0702.queue.api.events.AutoQueueEvent;
+import us.ajg0702.queue.api.events.AutoQueueOnKickEvent;
 import us.ajg0702.queue.api.events.SuccessfulSendEvent;
 import us.ajg0702.queue.api.players.AdaptedPlayer;
 import us.ajg0702.queue.api.players.QueuePlayer;
@@ -163,12 +163,15 @@ public class EventHandlerImpl implements EventHandler {
                 main.getTaskManager().runLater(() -> {
                     if(!player.isConnected()) return;
 
-                    AutoQueueEvent event = new AutoQueueEvent(player, from.getName());
+                    AutoQueueOnKickEvent event = new AutoQueueOnKickEvent(player, from.getName());
                     main.call(event);
-                    String toName = event.getTargetServer();
+                    // Event declares that the addon/developer handle notifying the player of this cancellation
+                    if (!event.isCancelled()) {
+                        String toName = event.getTargetServer();
 
-                    player.sendMessage(main.getMessages().getComponent("auto-queued", "SERVER:"+toName));
-                    main.getQueueManager().addToQueue(player, toName);
+                        player.sendMessage(main.getMessages().getComponent("auto-queued", "SERVER:"+toName));
+                        main.getQueueManager().addToQueue(player, toName);
+                    }
                 }, (long) (main.getConfig().getDouble("auto-add-to-queue-on-kick-delay")*1000), TimeUnit.MILLISECONDS);
                 return;
             }

--- a/common/src/main/java/us/ajg0702/queue/common/EventHandlerImpl.java
+++ b/common/src/main/java/us/ajg0702/queue/common/EventHandlerImpl.java
@@ -6,6 +6,7 @@ import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import us.ajg0702.queue.api.EventHandler;
+import us.ajg0702.queue.api.events.AutoQueueEvent;
 import us.ajg0702.queue.api.events.SuccessfulSendEvent;
 import us.ajg0702.queue.api.players.AdaptedPlayer;
 import us.ajg0702.queue.api.players.QueuePlayer;
@@ -162,7 +163,10 @@ public class EventHandlerImpl implements EventHandler {
                 main.getTaskManager().runLater(() -> {
                     if(!player.isConnected()) return;
 
-                    String toName = from.getName();
+                    AutoQueueEvent event = new AutoQueueEvent(player, from.getName());
+                    main.call(event);
+                    String toName = event.getTargetServer();
+
                     player.sendMessage(main.getMessages().getComponent("auto-queued", "SERVER:"+toName));
                     main.getQueueManager().addToQueue(player, toName);
                 }, (long) (main.getConfig().getDouble("auto-add-to-queue-on-kick-delay")*1000), TimeUnit.MILLISECONDS);

--- a/common/src/main/java/us/ajg0702/queue/common/QueueManagerImpl.java
+++ b/common/src/main/java/us/ajg0702/queue/common/QueueManagerImpl.java
@@ -3,7 +3,9 @@ package us.ajg0702.queue.common;
 import com.google.common.collect.ImmutableList;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.Title;
+import us.ajg0702.queue.api.AjQueueAPI;
 import us.ajg0702.queue.api.QueueManager;
+import us.ajg0702.queue.api.events.BuildServersEvent;
 import us.ajg0702.queue.api.events.PreQueueEvent;
 import us.ajg0702.queue.api.players.AdaptedPlayer;
 import us.ajg0702.queue.api.players.QueuePlayer;
@@ -39,13 +41,15 @@ public class QueueManagerImpl implements QueueManager {
 
     public List<QueueServer> buildServers() {
         List<QueueServer> result = new ArrayList<>();
-        List<? extends AdaptedServer> servers = main.getPlatformMethods().getServers();
 
-        for(AdaptedServer server : servers) {
+        BuildServersEvent buildServersEvent = new BuildServersEvent(main.getPlatformMethods().getServers());
+        main.call(buildServersEvent);
+
+        for(AdaptedServer server : buildServersEvent.getServers()) {
             QueueServer previousServer = findServer(server.getName());
             List<QueuePlayer> previousPlayers = previousServer == null ? new ArrayList<>() : previousServer.getQueue();
             if(previousPlayers.size() > 0) {
-                main.getLogger().info("Adding "+previousPlayers.size()+" players back to the queue for "+server.getName());
+                Debug.info("Adding "+previousPlayers.size()+" players back to the queue for "+server.getName());
             }
             QueueServer queueServer = new QueueServerImpl(server.getName(), main, server, previousPlayers);
             if(previousServer != null) {
@@ -93,11 +97,10 @@ public class QueueManagerImpl implements QueueManager {
                 continue;
             }
 
-
             QueueServer previousServer = main.getQueueManager().findServer(groupName);
             List<QueuePlayer> previousPlayers = previousServer == null ? new ArrayList<>() : previousServer.getQueue();
             if(previousPlayers.size() > 0) {
-                main.getLogger().info("Adding "+previousPlayers.size()+" players back to the queue for "+groupName);
+                Debug.info("Adding "+previousPlayers.size()+" players back to the queue for "+groupName);
             }
 
             result.add(new QueueServerImpl(groupName, main, groupServers, previousPlayers));
@@ -580,7 +583,13 @@ public class QueueManagerImpl implements QueueManager {
                     +((ThreadPoolExecutor) pool).getActiveCount()+" threads");
         }
         try {
-            for(AdaptedServer server : main.getPlatformMethods().getServers()) {
+            // Create a 'set' of AdaptedServer by server name
+            Map<String, AdaptedServer> serverMap = new HashMap<>();
+            for (QueueServer qServer : servers) {
+                qServer.getServers().forEach(server -> serverMap.put(server.getName(), server));
+            }
+            // Ping each server (registered in buildServers and affected by BuildServersEvent)
+            for (AdaptedServer server : serverMap.values()) {
                 pool.submit(() -> server.ping(main.getConfig().getBoolean("pinger-debug"), main.getLogger()));
             }
         } catch(Exception e) {
@@ -654,8 +663,9 @@ public class QueueManagerImpl implements QueueManager {
                     ) continue;
 
                     player.sendMessage(msgs.getComponent("status.sending-now", "SERVER:"+server.getAlias()));
-                    Debug.info("Calling player.connect for " + player.getName() + "(send when back online)");
-                    player.connect(selected);
+                    Debug.info("Calling QueuePlayer.connect for " + player.getName() + "(send when back online)");
+                    // Use QueuePlayer.connect which will fire the PreConnectEvent then call player.connect
+                    p.connect(selected);
                 }
                 continue;
             }
@@ -788,6 +798,7 @@ public class QueueManagerImpl implements QueueManager {
                                 )
                         );
                     } else {
+                        // Use direct connect method, as opposed to the QueuePlayer connect
                         selectedPlayer.connect(kickTo);
                         selectedPlayer.sendMessage(main.getMessages().getComponent("errors.kicked-to-make-room"));
 
@@ -838,8 +849,9 @@ public class QueueManagerImpl implements QueueManager {
 
 
             server.setLastSentTime(System.currentTimeMillis());
-            Debug.info("calling nextPlayer.connect on " + nextPlayer.getName());
-            nextPlayer.connect(selected);
+            Debug.info("calling nextQueuePlayer.connect on " + nextPlayer.getName());
+            // Use QueuePlayer.connect which will fire the PreConnectEvent then call player.connect
+            nextQueuePlayer.connect(selected);
             selected.addPlayer();
             Debug.info(selected.getName()+" player count is now set to "+ selected.getPlayerCount());
         }

--- a/common/src/main/java/us/ajg0702/queue/common/players/QueuePlayerImpl.java
+++ b/common/src/main/java/us/ajg0702/queue/common/players/QueuePlayerImpl.java
@@ -134,20 +134,11 @@ public class QueuePlayerImpl implements QueuePlayer {
 
         PreConnectEvent preConnectEvent = new PreConnectEvent(server, player);
         QueueMain.getInstance().call(preConnectEvent);
+
+        // Event declares that the addon/developer handle notifying the player of this cancellation
+        if (preConnectEvent.isCancelled()) { return; }
+
         // Fetch an addon-supplied handle if available, or use the existing server handle (default behavior)
-        server = preConnectEvent.getTargetServer();
-        if (preConnectEvent.getDelayStatus() != null) {
-            Messages msgs = QueueMain.getInstance().getMessages();
-
-            player.sendActionBar(msgs.getComponent("spigot.actionbar.offline",
-                    "POS:"+getPosition(),
-                    "LEN:"+getQueueServer().getQueue().size(),
-                    "SERVER:"+server.getName(),
-                    "STATUS:"+preConnectEvent.getDelayStatus()
-            ));
-            return;
-        }
-
-        player.connect(server);
+        player.connect(preConnectEvent.getTargetServer());
     }
 }

--- a/common/src/main/java/us/ajg0702/queue/common/players/QueuePlayerImpl.java
+++ b/common/src/main/java/us/ajg0702/queue/common/players/QueuePlayerImpl.java
@@ -132,7 +132,7 @@ public class QueuePlayerImpl implements QueuePlayer {
             throw new IllegalArgumentException("Player must be online!");
         }
 
-        PreConnectEvent preConnectEvent = new PreConnectEvent(server, player);
+        PreConnectEvent preConnectEvent = new PreConnectEvent(server, this);
         QueueMain.getInstance().call(preConnectEvent);
 
         // Event declares that the addon/developer handle notifying the player of this cancellation

--- a/common/src/main/java/us/ajg0702/queue/common/players/QueuePlayerImpl.java
+++ b/common/src/main/java/us/ajg0702/queue/common/players/QueuePlayerImpl.java
@@ -2,10 +2,13 @@ package us.ajg0702.queue.common.players;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import us.ajg0702.queue.api.events.PreConnectEvent;
 import us.ajg0702.queue.api.players.AdaptedPlayer;
 import us.ajg0702.queue.api.players.QueuePlayer;
 import us.ajg0702.queue.api.queues.QueueServer;
 import us.ajg0702.queue.api.server.AdaptedServer;
+import us.ajg0702.queue.common.QueueMain;
+import us.ajg0702.utils.common.Messages;
 
 import java.util.UUID;
 
@@ -120,5 +123,31 @@ public class QueuePlayerImpl implements QueuePlayer {
     private long leaveTime = 0;
     public void setLeaveTime(long leaveTime) {
         this.leaveTime = leaveTime;
+    }
+
+    @Override
+    public void connect(@NotNull AdaptedServer server) {
+        AdaptedPlayer player = getPlayer();
+        if (player == null) {
+            throw new IllegalArgumentException("Player must be online!");
+        }
+
+        PreConnectEvent preConnectEvent = new PreConnectEvent(server, player);
+        QueueMain.getInstance().call(preConnectEvent);
+        // Fetch an addon-supplied handle if available, or use the existing server handle (default behavior)
+        server = preConnectEvent.getTargetServer();
+        if (preConnectEvent.getDelayStatus() != null) {
+            Messages msgs = QueueMain.getInstance().getMessages();
+
+            player.sendActionBar(msgs.getComponent("spigot.actionbar.offline",
+                    "POS:"+getPosition(),
+                    "LEN:"+getQueueServer().getQueue().size(),
+                    "SERVER:"+server.getName(),
+                    "STATUS:"+preConnectEvent.getDelayStatus()
+            ));
+            return;
+        }
+
+        player.connect(server);
     }
 }


### PR DESCRIPTION
- AutoQueueEvent - Called when AjQueue goes to re-queue a player for a server after being kicked. This event allows devs to view and edit the server the player will be re-queued to.
- BuildServersEvent - Called when AjQueue recompiles the list of available servers for queuing. Allows devs to add and remove AdaptedServer objects from this list. Allows hiding of existing servers on Velocity/Bungee, and registering new ones using an implementation of AdaptedServer.
- PreConnectEvent - Called right before AjQueue connects a player to a server. Devs can view and edit the target server. An example would be registering a dummy AdaptedServer in BuildServersEvent, which you detect in PreConnectEvent and use your own logic to set a valid server to go to.