### PR TITLE
Adding proxy allow-only-slash-servers-for-queueing config option

### DIFF
--- a/api/src/main/java/us/ajg0702/queue/api/Implementation.java
+++ b/api/src/main/java/us/ajg0702/queue/api/Implementation.java
@@ -8,4 +8,5 @@ public interface Implementation {
     default void unregisterCommand(IBaseCommand command) {
         unregisterCommand(command.getName());
     }
+    void reload();
 }

--- a/common/src/main/java/us/ajg0702/queue/commands/commands/manage/Reload.java
+++ b/common/src/main/java/us/ajg0702/queue/commands/commands/manage/Reload.java
@@ -55,6 +55,7 @@ public class Reload extends SubCommand {
         main.getQueueManager().reloadServers();
         main.getMessages().reload();
         main.getSlashServerManager().reload();
+        main.getImplementation().reload();
 
         main.getUpdater().setEnabled(main.getConfig().getBoolean("enable-updater"));
 

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -163,6 +163,13 @@ remove-player-on-server-switch: false
 #  Default: false
 enable-server-command: false
 
+# When set: /queue and its aliases are not registered, making slash-servers commands the only way for players
+# to queue-up.
+# Warning: This setting only effects the proxy commands, if the plugin is also installed on your Bukkit server
+# the queue command will still be available.
+#  Default: false
+allow-only-slash-servers-for-queueing: false
+
 # What servers should we make slash server commands for?
 # For example, if survival is in this list, then if a player executes /survival
 #  then they will be put in the queue for survival
@@ -389,7 +396,7 @@ debug: false
 
 
 # Don't touch this number please
-config-version: 44
+config-version: 45
 
 
 # This is ONLY here so that they can be moved to messages.yml. Please edit these in messages.yml!

--- a/platforms/bungeecord/src/main/java/us/ajg0702/queue/platforms/bungeecord/BungeeQueue.java
+++ b/platforms/bungeecord/src/main/java/us/ajg0702/queue/platforms/bungeecord/BungeeQueue.java
@@ -66,8 +66,9 @@ public class BungeeQueue extends Plugin implements Listener, Implementation {
                 new ManageCommand(main)
         );
 
-        for(IBaseCommand command : commands) {
-            registerCommand(command);
+        int i = main.getConfig().getBoolean("allow-only-slash-servers-for-queueing") ? 1 : 0;
+        for(; i < commands.size(); i++) {
+            registerCommand(commands.get(i));
         }
 
         getProxy().getPluginManager().registerListener(this, this);
@@ -166,6 +167,20 @@ public class BungeeQueue extends Plugin implements Listener, Implementation {
         commandMap.put(command.getName(), bungeeCommand);
         getProxy().getPluginManager()
                 .registerCommand(this, bungeeCommand);
+    }
+
+    @Override
+    public void reload() {
+        boolean wantQueueCommandRegistered = !main.getConfig().getBoolean("allow-only-slash-servers-for-queueing");
+        if (wantQueueCommandRegistered != commandMap.containsKey(commands.get(0).getName())) {
+            if (!wantQueueCommandRegistered) {
+                main.getLogger().warn("Reload is unregistering /queue command");
+                unregisterCommand(commands.get(0).getName());
+            } else {
+                main.getLogger().warn("Reload is registering /queue command");
+                registerCommand(commands.get(0));
+            }
+        }
     }
 
     public QueueMain getMain() {

--- a/platforms/velocity/src/main/java/us/ajg0702/queue/platforms/velocity/VelocityQueue.java
+++ b/platforms/velocity/src/main/java/us/ajg0702/queue/platforms/velocity/VelocityQueue.java
@@ -67,6 +67,8 @@ public class VelocityQueue implements Implementation {
 
     List<IBaseCommand> commands;
 
+    private boolean isQueueCommandRegistered;
+
     CommandManager commandManager;
 
     @Subscribe
@@ -92,9 +94,10 @@ public class VelocityQueue implements Implementation {
         proxyServer.getChannelRegistrar().register(MinecraftChannelIdentifier.create("ajqueue", "tospigot"));
         proxyServer.getChannelRegistrar().register(MinecraftChannelIdentifier.from("ajqueue:toproxy"));
 
-
-        for(IBaseCommand command : commands) {
-            registerCommand(command);
+        isQueueCommandRegistered = !main.getConfig().getBoolean("allow-only-slash-servers-for-queueing");
+        int i = isQueueCommandRegistered ? 0 : 1;
+        for(; i < commands.size(); i++) {
+            registerCommand(commands.get(i));
         }
 
 
@@ -164,6 +167,22 @@ public class VelocityQueue implements Implementation {
                         .build(),
                 new VelocityCommand(main, (BaseCommand) command)
         );
+    }
+
+    @Override
+    public void reload() {
+        boolean wantQueueCommandRegistered = !main.getConfig().getBoolean("allow-only-slash-servers-for-queueing");
+        if (wantQueueCommandRegistered != isQueueCommandRegistered) {
+            if (!wantQueueCommandRegistered) {
+                main.getLogger().warn("Reload is unregistering /queue command");
+                unregisterCommand(commands.get(0).getName());
+                isQueueCommandRegistered = false;
+            } else {
+                main.getLogger().warn("Reload is registering /queue command");
+                registerCommand(commands.get(0));
+                isQueueCommandRegistered = true;
+            }
+        }
     }
 
     public QueueMain getMain() {


### PR DESCRIPTION
Adding proxy allow-only-slash-servers-for-queueing config option to enable/disable the `/queue` command and its aliases. Note that the defined slash-servers commands work no matter the state of this boolean. Changing this setting does not require a server restart (running `/ajqueue reload` will do).

Motivation for this change is be able to allow other plugins to use the /queue command while still allowing players to move about with slash-servers.