### PR TITLE
add dynamic max player cap functionality

### DIFF
--- a/api/src/main/java/us/ajg0702/queue/api/premium/Logic.java
+++ b/api/src/main/java/us/ajg0702/queue/api/premium/Logic.java
@@ -64,7 +64,7 @@ public interface Logic {
             boolean hasMakeRoom = player.hasPermission("ajqueue.make-room") && AjQueueAPI.getInstance().getConfig().getBoolean("enable-make-room-permission");
             if(
                     (server.isFull() && (server.canJoinFull(player) || hasMakeRoom)) ||
-                            (queueServer.isManuallyFull() && (AdaptedServer.canJoinFull(player, queueServer.getName()) || hasMakeRoom))) {
+                            ((queueServer.isManuallyFull() || queueServer.isDynamicallyFull()) && (AdaptedServer.canJoinFull(player, queueServer.getName()) || hasMakeRoom))) {
                 highest = Math.max(highest, fulljoinPriority);
             }
         }

--- a/api/src/main/java/us/ajg0702/queue/api/queues/QueueServer.java
+++ b/api/src/main/java/us/ajg0702/queue/api/queues/QueueServer.java
@@ -1,6 +1,7 @@
 package us.ajg0702.queue.api.queues;
 
 import com.google.common.collect.ImmutableList;
+import org.jetbrains.annotations.Nullable;
 import us.ajg0702.queue.api.players.AdaptedPlayer;
 import us.ajg0702.queue.api.players.QueuePlayer;
 import us.ajg0702.queue.api.queueholders.QueueHolder;
@@ -92,6 +93,13 @@ public interface QueueServer {
      * @param amount the new dynamic max player count. Negative values will be ignored, behaving as resetDynamicMax
      */
     void setDynamicMax(int amount);
+
+    /**
+     * Gets the dynamic max (null when no max is set)
+     * @return integer (0 or larger) or null if no dynamic max is set
+     */
+    @Nullable
+    Integer getDynamicMax();
 
     /**
      * Resets the dynamic max player cap for this server/group. This will make it so the dynamic player cap is no longer a consideration.

--- a/api/src/main/java/us/ajg0702/queue/api/queues/QueueServer.java
+++ b/api/src/main/java/us/ajg0702/queue/api/queues/QueueServer.java
@@ -82,6 +82,23 @@ public interface QueueServer {
     boolean isManuallyFull();
 
     /**
+     * Checks if the total number of players in this server/group is above the dynamically-set max player count
+     * @return If the server is at or above the dynamically-set player limit
+     */
+    boolean isDynamicallyFull();
+
+    /**
+     * Sets the dynamic max player cap for this server/group. This is used for temporarily lowering the max player count of a server/group.
+     * @param amount the new dynamic max player count. Negative values will be ignored, behaving as resetDynamicMax
+     */
+    void setDynamicMax(int amount);
+
+    /**
+     * Resets the dynamic max player cap for this server/group. This will make it so the dynamic player cap is no longer a consideration.
+     */
+    void resetDynamicMax();
+
+    /**
      * Pauses or unpauses a server
      * @param paused true = paused, false = unpaused
      */

--- a/common/src/main/java/us/ajg0702/queue/common/QueueManagerImpl.java
+++ b/common/src/main/java/us/ajg0702/queue/common/QueueManagerImpl.java
@@ -875,7 +875,7 @@ public class QueueManagerImpl implements QueueManager {
 
                     if(
                             (selected.isFull() && !selected.canJoinFull(player)) ||
-                                    (server.isManuallyFull() && !AdaptedServer.canJoinFull(player, server.getName()))
+                                    ((server.isManuallyFull() || server.isDynamicallyFull()) && !AdaptedServer.canJoinFull(player, server.getName()))
                     ) continue;
 
                     player.sendMessage(msgs.getComponent("status.sending-now", "SERVER:"+server.getAlias()));
@@ -945,12 +945,12 @@ public class QueueManagerImpl implements QueueManager {
             if(
                     (
                             (selected.isFull() && !selected.canJoinFull(nextPlayer)) ||
-                            (server.isManuallyFull() && !AdaptedServer.canJoinFull(nextPlayer, server.getName()))
+                            ((server.isManuallyFull() || server.isDynamicallyFull()) && !AdaptedServer.canJoinFull(nextPlayer, server.getName()))
                     ) &&
                             !(
                                     nextPlayer.hasPermission("ajqueue.make-room") &&
                                             main.getConfig().getBoolean("enable-make-room-permission") &&
-                                            (!server.isGroup() || server.isManuallyFull()) // only use make-room on groups if the server is manually full
+                                            (!server.isGroup() || server.isManuallyFull() || server.isDynamicallyFull()) // only use make-room on groups if the server is manually or dynamically full
                             )
             ) continue;
 
@@ -959,11 +959,11 @@ public class QueueManagerImpl implements QueueManager {
             if(
                     (
                             (selected.isFull() && !selected.canJoinFull(nextPlayer)) ||
-                                    (server.isManuallyFull() && !AdaptedServer.canJoinFull(nextPlayer, server.getName()))
+                                    ((server.isManuallyFull() || server.isDynamicallyFull()) && !AdaptedServer.canJoinFull(nextPlayer, server.getName()))
                     ) &&
                             main.getConfig().getBoolean("enable-make-room-permission") &&
                             nextPlayer.hasPermission("ajqueue.make-room") &&
-                            (!server.isGroup() || server.isManuallyFull()) && // only use make-room on groups if the server is manually full
+                            (!server.isGroup() || server.isManuallyFull() || server.isDynamicallyFull()) && // only use make-room on groups if the server is manually or dynamically full
                             ( // don't make room more than the minimum ping time
                                     System.currentTimeMillis() - makeRoomAntispam.getOrDefault(nextQueuePlayer, 0L)
                                             >= (main.getConfig().getDouble("minimum-ping-time") * 1e3)

--- a/common/src/main/java/us/ajg0702/queue/common/queues/QueueServerImpl.java
+++ b/common/src/main/java/us/ajg0702/queue/common/queues/QueueServerImpl.java
@@ -43,6 +43,7 @@ public class QueueServerImpl implements QueueServer {
     private double averageSendTime = 0;
 
     private int manualMaxPlayers = Integer.MAX_VALUE;
+    private Integer dynamicMaxPlayers = null;
 
     private QueueType lastQueueSend = QueueType.STANDARD;
     private int sendCount = 0;
@@ -273,7 +274,7 @@ public class QueueServerImpl implements QueueServer {
 
     @Override
     public boolean isJoinable(AdaptedPlayer p, boolean ignoreFull) {
-        if(!ignoreFull && isManuallyFull() && !AdaptedServer.canJoinFull(p, getName())) return false;
+        if(!ignoreFull && (isManuallyFull() || isDynamicallyFull()) && !AdaptedServer.canJoinFull(p, getName())) return false;
         AdaptedServer server = getIdealServer(p);
         if(server == null) return false;
         return server.isJoinable(p, ignoreFull) && !isPaused();
@@ -296,6 +297,33 @@ public class QueueServerImpl implements QueueServer {
 //        Debug.info(total + " >= " + getManualMaxPlayers() + " = " + (total >= getManualMaxPlayers()));
 
         return total >= getManualMaxPlayers();
+    }
+
+    @Override
+    public boolean isDynamicallyFull() {
+        if (this.dynamicMaxPlayers == null) {
+            return false;
+        }
+        int total = 0;
+        for (AdaptedServer server : servers) {
+            Optional<AdaptedServerPing> lastPing = server.getLastPing();
+            if(!lastPing.isPresent()) continue;
+            total += lastPing.get().getPlayerCount();
+        }
+        return total >= this.dynamicMaxPlayers;
+    }
+
+    @Override
+    public void setDynamicMax(int amount) {
+        if (amount < 0) {
+            this.resetDynamicMax();
+        }
+        this.dynamicMaxPlayers = amount;
+    }
+
+    @Override
+    public void resetDynamicMax() {
+        this.dynamicMaxPlayers = null;
     }
 
     @Override

--- a/common/src/main/java/us/ajg0702/queue/common/queues/QueueServerImpl.java
+++ b/common/src/main/java/us/ajg0702/queue/common/queues/QueueServerImpl.java
@@ -165,7 +165,7 @@ public class QueueServerImpl implements QueueServer {
             return msgs.getString("status.offline.whitelisted");
         }
 
-        if((server.isFull() && !server.canJoinFull(p)) || (isManuallyFull() && !AdaptedServer.canJoinFull(p, getName()))) {
+        if((server.isFull() && !server.canJoinFull(p)) || ((isManuallyFull() || isDynamicallyFull()) && !AdaptedServer.canJoinFull(p, getName()))) {
             return msgs.getString("status.offline.full");
         }
 
@@ -201,7 +201,7 @@ public class QueueServerImpl implements QueueServer {
             return "whitelisted";
         }
 
-        if(((server.isFull() && !server.canJoinFull(p)) || (isManuallyFull() && !AdaptedServer.canJoinFull(p, getName())))) {
+        if(((server.isFull() && !server.canJoinFull(p)) || ((isManuallyFull() || isDynamicallyFull()) && !AdaptedServer.canJoinFull(p, getName())))) {
             return "full";
         }
 

--- a/common/src/main/java/us/ajg0702/queue/common/queues/QueueServerImpl.java
+++ b/common/src/main/java/us/ajg0702/queue/common/queues/QueueServerImpl.java
@@ -1,6 +1,7 @@
 package us.ajg0702.queue.common.queues;
 
 import com.google.common.collect.ImmutableList;
+import org.jetbrains.annotations.Nullable;
 import us.ajg0702.queue.api.AjQueueAPI;
 import us.ajg0702.queue.api.events.PositionChangeEvent;
 import us.ajg0702.queue.api.players.AdaptedPlayer;
@@ -319,6 +320,11 @@ public class QueueServerImpl implements QueueServer {
             this.resetDynamicMax();
         }
         this.dynamicMaxPlayers = amount;
+    }
+
+    @Override
+    public @Nullable Integer getDynamicMax() {
+        return this.dynamicMaxPlayers;
     }
 
     @Override


### PR DESCRIPTION
adds a separate full tracker. this is useful because we set the max player cap dynamically based on server loads during peak hours. I guess this could also be used similarly to the pause feature, but its dramatically easier to work with that having to switch pause/unpause on each player count update, specially if the redis queue feature is merged (because it would lead to out of sync player counts). This is instance local and independent to the redis mr. Currently only coded to be used via the API.